### PR TITLE
fix: optional and missing http property should not raise an error

### DIFF
--- a/projects/ngx-sentry/src/lib/sentry.interceptor.ts
+++ b/projects/ngx-sentry/src/lib/sentry.interceptor.ts
@@ -44,7 +44,11 @@ export class SentryErrorInterceptor implements HttpInterceptor {
      * @returns - An boolean describing if the response should be handled
      */
     private filter(response: HttpErrorResponse): boolean {
-        if (!this.options.enabled || (this.options.http && this.options.http.enabled === false)) {
+        if (!this.options.enabled) {
+            return false
+        }
+
+        if (!this.options.http || this.options.http.enabled === false) {
             return false
         }
 


### PR DESCRIPTION
Module configuration interface specifies
the `http` key as optional.
But interceptor will throw an error when it's missing.

This will throw an error (when it should not):

```typescript
SentryModule.forRoot({
  enabled: true,
  sentry: {
    dsn: environment.sentryDsn,
  }
}
```